### PR TITLE
refactor: Upgrade to HCL2 (terraform v0.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository will use EC2 instances to deploy the service but we can easily
 swap this by a kubernetes cluster (commonly used in micro-services environment).
 We are going to use EC2 instances here to reduce dependencies in this PoC.
 
-This infrastructure is coded as a module so we can run end to end tests using
-test-kitchen.
+This infrastructure is coded in HCL2 as a module so we can run end to end tests
+using test-kitchen.
 
 ## Micro Service
 
@@ -31,7 +31,7 @@ dependencies simple.
 * TravisCI
 * Docker and DockerHub
 * GitHub (as you can see)
-* Terraform
+* Terraform (>= v0.12.0)
 * Test Kitchen (to test Infrastructure as Code)
 * AWS (to run the service)
 * CoreOS (with `cloud-config`)

--- a/terraform/requirements.tf
+++ b/terraform/requirements.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.0"
+}


### PR DESCRIPTION
Upgrade project to HCL2 with terraform v0.12.0

* Add requirements.tf with terraform v0.12.0 minimum
* Update README.tf to specify this is a module in HCL2