### PR TITLE
refactor: Move EC2 instance to private subnets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 rvm:
-  - 2.3.1
+  - 2.4.2
 
 sudo: true
 
@@ -22,12 +22,12 @@ install:
 
 before_script:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - kitchen create
+  - bundle exec kitchen create
 
 script:
   - docker build -t gbergere/micro-service-as-code:${TRAVIS_COMMIT} .
   - docker push gbergere/micro-service-as-code:${TRAVIS_COMMIT}
-  - kitchen verify
+  - bundle exec kitchen verify
 
 after_script:
-  - kitchen destroy
+  - bundle exec kitchen destroy

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
+
+ruby "2.4.2"
+
 source 'https://rubygems.org/' do
-  gem 'kitchen-terraform', "~> 4.0"
+  gem 'kitchen-terraform', "~> 4.1"
 end

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -29,7 +29,7 @@ resource "aws_autoscaling_group" "ec2" {
   name_prefix          = "${var.name_prefix}"
   launch_configuration = "${aws_launch_configuration.ec2.name}"
   target_group_arns    = ["${aws_lb_target_group.g.arn}"]
-  vpc_zone_identifier  = ["${var.subnets}"]
+  vpc_zone_identifier  = ["${var.subnets["private"]}"]
 
   min_size                  = 2
   max_size                  = 2

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -8,7 +8,7 @@ resource "random_id" "target_group" {
 
 resource "aws_lb" "lb" {
   name            = "${var.name_prefix}lb-${random_id.lb.hex}"
-  subnets         = ["${var.subnets}"]
+  subnets         = ["${var.subnets["public"]}"]
   security_groups = ["${aws_security_group.lb.id}"]
 
   enable_cross_zone_load_balancing = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "vpc_id" {}
 variable "app_version" {}
 
 variable "subnets" {
-  type = "list"
+  type = "map"
 }
 
 variable "additional_security_groups" {

--- a/test/fixtures/wrapper/test.tf
+++ b/test/fixtures/wrapper/test.tf
@@ -8,6 +8,8 @@ module "vpc" {
   source = "github.com/gbergere/tf-vpc-module"
 
   name_prefix = "${local.name_prefix}"
+
+  price_saving_enabled = "1"
 }
 
 module "app" {
@@ -16,7 +18,7 @@ module "app" {
   name_prefix = "${local.name_prefix}"
 
   vpc_id                     = "${module.vpc.vpc_id}"
-  subnets                    = ["${module.vpc.subnets["public"]}"]
+  subnets                    = "${module.vpc.subnets}"
   additional_security_groups = ["${module.vpc.default_security_group}"]
 
   app_version = "${var.app_version}"


### PR DESCRIPTION
Seggregate subnets (with private/public tiers), EC2 instances in private
subnets, LoadBalancer in public subnets.

* Update EC2 subnets to be private.
* Update VPC to run in saving mode `price_saving_enabled = True`.